### PR TITLE
feat: loosening up the npm engine requirements to easily allow npm@8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      # Node 16 still ships with npm@8 so for compatibility reasons we're upping this for everything else.
+      - name: Install npm@8
+        if: matrix.node-version != '16.x'
+        run: npm install -g npm@8
+
       - name: Install deps
         run: npm ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      # Node 12 still ships with npm@6 so for compatibility reasons we're upping this.
+      # Node 16 still ships with npm@8 so for compatibility reasons we're upping this for everything else.
       - name: Install npm@8
-        if: matrix.node-version == '12.x'
+        if: matrix.node-version != '16.x'
         run: npm install -g npm@8
 
       - name: Install deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Install npm@7
-        run: npm install -g npm@7
+      # Node 12 still ships with npm@6 so for compatibility reasons we're upping this.
+      - name: Install npm@8
+        if: matrix.node-version == '12.x'
+        run: npm install -g npm@8
 
       - name: Install deps
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      # Node 16 still ships with npm@8 so for compatibility reasons we're upping this for everything else.
-      - name: Install npm@8
-        if: matrix.node-version != '16.x'
-        run: npm install -g npm@8
-
       - name: Install deps
         run: npm ci
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,7 @@
         "typescript": "^4.4.4"
       },
       "engines": {
-        "node": "^12 || ^14 || ^16",
-        "npm": "^7"
+        "node": "^12 || ^14 || ^16"
       },
       "peerDependencies": {
         "oas": "^17.1.0"

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "url": "git://github.com/readmeio/oas-extensions.git"
   },
   "engines": {
-    "node": "^12 || ^14 || ^16",
-    "npm": "^7"
+    "node": "^12 || ^14 || ^16"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## 🧰 What's being changed?

Installing this library with npm@8 generates a warning that it actually wants npm@7. Since either work, and the npm requirement is only really there for local development I'm removing it.

And in order to make sure that the library still works okay without this on Node 12 and Node 14 I'm updating our CI workflow to install npm@8 on these versions. This is unnecessary on Node 16 because Node 16 ships with npm@8 already. 

## 🧬 Testing

* [ ] Tests pass?