### PR TITLE
fix: ignore the `code-samples` extension if placed at the root level

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -63,6 +63,23 @@ describe('#getExtension', () => {
 
       expect(extensions.getExtension(extensions.SAMPLES_LANGUAGES, oas)).toHaveLength(5);
     });
+
+    it('should not pick up the `code-samples` extension', () => {
+      const oas = Oas.init({
+        ...petstore,
+        'x-readme': {
+          [extensions.CODE_SAMPLES]: [
+            {
+              name: 'Custom cURL snippet',
+              language: 'curl',
+              code: 'curl -X POST https://api.example.com/v2/alert',
+            },
+          ],
+        },
+      });
+
+      expect(extensions.getExtension(extensions.CODE_SAMPLES, oas)).toBeUndefined();
+    });
   });
 
   describe('operation-level', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,12 @@ export function getExtension(extension: keyof Extensions, oas: Oas, operation?: 
     }
   }
 
+  // Because our `code-samples` extension is intended for operation-level use, if it's instead placed at the OAS-level
+  // we should ignore it.
+  if (extension === CODE_SAMPLES) {
+    return defaults[extension];
+  }
+
   if (oas.hasExtension('x-readme')) {
     const data = oas.getExtension('x-readme') as Extensions;
     if (data && typeof data === 'object' && extension in data) {


### PR DESCRIPTION
## 🧰 What's being changed?

Because our [custom code samples](https://docs.readme.com/docs/openapi-extensions#custom-code-samples) extension is only intended to be used, or rather only makes sense, at the operation-level we're going to start ignoring it if it's present at the root OAS.

Fix in support of RM-3217.
