### PR TITLE
feat: adding two more languages into our default set of languages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.nyc_output/
 @types/
 coverage/
 dist/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,2 @@
 .nyc_output/
-@types/
-coverage/
 dist/

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export const defaults: Extensions = {
   [HEADERS]: undefined,
   [PROXY_ENABLED]: true,
   [SAMPLES_ENABLED]: true,
-  [SAMPLES_LANGUAGES]: ['curl', 'node', 'ruby', 'php', 'python'],
+  [SAMPLES_LANGUAGES]: ['shell', 'node', 'ruby', 'php', 'python', 'java', 'csharp'],
   [SEND_DEFAULTS]: false,
   [SIMPLE_MODE]: true,
 };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -23,24 +23,26 @@ describe('oas-extensions', function () {
   describe('#getExtension', function () {
     it("should not throw an exception if `Oas` doesn't have an API definition", function () {
       const oas = Oas.init(undefined);
-      expect(extensions.getExtension(extensions.SAMPLES_LANGUAGES, oas)).to.have.length(5);
+      expect(extensions.getExtension(extensions.SAMPLES_LANGUAGES, oas)).to.have.length(7);
     });
 
     it("should not throw an exception if `Operation` doesn't have an API definition", function () {
       const oas = Oas.init(undefined);
       const operation = oas.operation('/pet', 'post');
-      expect(extensions.getExtension(extensions.SAMPLES_LANGUAGES, oas, operation)).to.have.length(5);
+      expect(extensions.getExtension(extensions.SAMPLES_LANGUAGES, oas, operation)).to.have.length(7);
     });
 
     describe('oas-level extensions', function () {
       it('should use the default extension value if the extension is not present', function () {
         const oas = Oas.init(petstore);
         expect(extensions.getExtension(extensions.SAMPLES_LANGUAGES, oas)).to.deep.equal([
-          'curl',
+          'shell',
           'node',
           'ruby',
           'php',
           'python',
+          'java',
+          'csharp',
         ]);
       });
 
@@ -66,7 +68,7 @@ describe('oas-extensions', function () {
           'x-readme': true,
         });
 
-        expect(extensions.getExtension(extensions.SAMPLES_LANGUAGES, oas)).to.have.length(5);
+        expect(extensions.getExtension(extensions.SAMPLES_LANGUAGES, oas)).to.have.length(7);
       });
 
       it('should not pick up the `code-samples` extension', function () {
@@ -98,11 +100,13 @@ describe('oas-extensions', function () {
         const operation = oas.operation('/pet', 'post');
 
         expect(extensions.getExtension(extensions.SAMPLES_LANGUAGES, oas, operation)).to.deep.equal([
-          'curl',
+          'shell',
           'node',
           'ruby',
           'php',
           'python',
+          'java',
+          'csharp',
         ]);
       });
 
@@ -126,7 +130,7 @@ describe('oas-extensions', function () {
         const operation = oas.operation('/pet', 'post');
         operation.schema['x-readme'] = true;
 
-        expect(extensions.getExtension(extensions.SAMPLES_LANGUAGES, oas)).to.have.length(5);
+        expect(extensions.getExtension(extensions.SAMPLES_LANGUAGES, oas)).to.have.length(7);
       });
     });
   });


### PR DESCRIPTION
| 🚥 Fix RM-4662 |
| :-- |

## 🧰 Changes

* [x] Adds `java` and `csharp` into our `x-readme.samples-languages` extension. Our `LanguagePicker` component in ReadMe will handle if we actually show these two additional languages or not depending on where the `LanguagePicker` is being rendered.
* [x] Update the `samples-languages` extension to rename `curl` to `shell`. `@readme/oas-to-snippet` has tests in place for recognizing and mapping `curl` to `shell` so this is a non-breaking change.