### PR TITLE
feat: adding an optional `install` property to the code samples extension

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export type Extensions = {
     language: string;
     code: string;
     name?: string;
+    install?: string;
   };
   [EXPLORER_ENABLED]: boolean;
   [HEADERS]: Record<string, string | number>[];

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -152,7 +152,19 @@ describe('oas-extensions', function () {
     });
 
     [
-      ['CODE_SAMPLES', [], false, 'Array'],
+      [
+        'CODE_SAMPLES',
+        [
+          {
+            name: 'Custom cURL snippet',
+            language: 'curl',
+            code: 'curl -X POST https://api.example.com/v2/alert',
+            install: 'brew install curl',
+          },
+        ],
+        false,
+        'Array',
+      ],
       ['EXPLORER_ENABLED', true, 'false', 'Boolean'],
       ['HEADERS', [{ key: 'X-API-Key', value: 'abc123' }], false, 'Array'],
       ['PROXY_ENABLED', true, 'yes', 'Boolean'],


### PR DESCRIPTION
| 🚥 Fix RM-1897 |
| :-- |

## 🧰 Changes

So folks who have custom code samples can tell their users how to install whatever library the code sample uses I'm adding a new `install` property to the `x-code-samples` extension schema.